### PR TITLE
only supply the item schema for additional properties

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -285,9 +285,7 @@ func (sg *SchemaGenerator) fieldSchema(f MessageField) (*openapi3.SchemaRef, err
 			return nil, fmt.Errorf("failed to generate array item schema: %w", err)
 		}
 
-		hasSchemaRef := true
 		schema.AdditionalProperties = openapi3.AdditionalProperties{
-			Has:    &hasSchemaRef,
 			Schema: itemSchema,
 		}
 


### PR DESCRIPTION
`Has` and `Schema` are mutually exclusive, with `Has` taking precedence. The change introduced in 7bd26b5b75b7afcc386c05c81854c7e176def11b made all maps into `additionalProperties: true`, without any schema information:

```diff
@@ -62,9 +61,7 @@
             "type": "string"
           },
           "meta": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": true,
             "description": "Meta data to include with the delete record.",
             "type": "object"
           },
@@ -118,9 +115,7 @@
             "type": "integer"
           },
           "heads": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/elephant.repository.Status"
-            },
+            "additionalProperties": true,
             "description": "Heads are the last statuses.",
             "type": "object"
           },
```

This change restores the old behaviour, where the schema of the additional properties is specified.